### PR TITLE
use WHATWG URL when making request

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
+const {URL} = require('url');
 const got = require('got');
 const registryUrl = require('registry-url');
-const { URL } = require('url');
 
 module.exports = username => {
 	if (typeof username !== 'string') {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 'use strict';
 const got = require('got');
 const registryUrl = require('registry-url');
+const { URL } = require('url');
 
 module.exports = username => {
 	if (typeof username !== 'string') {
 		return Promise.reject(new Error('username required'));
 	}
 
-	const url = `${registryUrl()}-/user/org.couchdb.user:${username}`;
+	const url = new URL(`${registryUrl()}-/user/org.couchdb.user:${username}`);
 
 	return got(url, {json: true})
 		.then(res => res.body.email)


### PR DESCRIPTION
This module returns error(NOT FOUND) when calling username ex. "lukeramsden'" (note the ') - it is a valid user. When using WHATWG URL format it does not encode the "'" and the request returns the user successfully