### PR TITLE
Use WHATWG URL when calling Got

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '7'
   - '6'
   - '4'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
+const {URL} = require('url');
 const got = require('got');
 const registryUrl = require('registry-url');
-const { URL } = require('url');
 
 module.exports = username => {
 	if (typeof username !== 'string') {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = username => {
 		return Promise.reject(new Error('username required'));
 	}
 
-	const url = new URL(`${registryUrl()}-/user/org.couchdb.user:${username}`);
+	const urlStr = `${registryUrl()}-/user/org.couchdb.user:${username}`;
+	const url = URL ? new URL(urlStr) : urlStr;
 
 	return got(url, {json: true})
 		.then(res => res.body.email)

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 'use strict';
 const got = require('got');
 const registryUrl = require('registry-url');
+const { URL } = require('url');
 
 module.exports = username => {
 	if (typeof username !== 'string') {
 		return Promise.reject(new Error('username required'));
 	}
 
-	const url = `${registryUrl()}-/user/org.couchdb.user:${username}`;
+	const url = new URL(`${registryUrl()}-/user/org.couchdb.user:${username}`);
 
 	return got(url, {json: true})
 		.then(res => res.body.email)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "get"
   ],
   "dependencies": {
-    "got": "^6.3.0",
+    "got": "^8.0.0",
     "registry-url": "^3.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ test('invalid input', async t => {
 
 test('unknown username', async t => {
 	const randomName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-	await t.throws(m(randomName));
+	await t.throws(m(randomName), `User ${randomName} doesn't exist`);
 });
 
 test('valid username', async t => {

--- a/test.js
+++ b/test.js
@@ -13,3 +13,7 @@ test('unknown username', t => {
 test('valid username', async t => {
 	t.is(await m('sindresorhus'), 'sindresorhus@gmail.com');
 });
+
+test('valid username with special char', async t => {
+	t.is(await m(`lukeramsden'`), 'lukeramsden8@gmail.com');
+});

--- a/test.js
+++ b/test.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 import m from './';
 
-test('invalid input', t => {
-	t.throws(m(1), 'username required');
+test('invalid input', async t => {
+	await t.throws(m(1), 'username required');
 });
 
-test('unknown username', t => {
+test('unknown username', async t => {
 	const randomName = `asdasfgrgafadsgaf${Math.random().toString().slice(2)}`;
-	t.throws(m(randomName), `User ${randomName} doesn't exist`);
+	await t.throws(m(randomName));
 });
 
 test('valid username', async t => {

--- a/test.js
+++ b/test.js
@@ -14,6 +14,11 @@ test('valid username', async t => {
 	t.is(await m('sindresorhus'), 'sindresorhus@gmail.com');
 });
 
-test('valid username with special char', async t => {
-	t.is(await m(`lukeramsden'`), 'lukeramsden8@gmail.com');
-});
+// If URL class is present (NODE v7 and above), execute the las test
+const {URL} = require('url');
+
+if (URL) {
+	test('valid username with special char', async t => {
+		t.is(await m(`lukeramsden'`), 'lukeramsden8@gmail.com');
+	});
+}


### PR DESCRIPTION
This way, requests for users like 
https://registry.npmjs.org/-/user/org.couchdb.user:lukeramsden' (NOTE the " **'** ")
... pass successfully. Otherwize, they get encoded and the request returns not found