### PR TITLE
Prioritize most recent packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ export default async function npmEmail(username) {
 	try {
 		const {results} = await got(url).json();
 
+		results.sort((a, b) => b.package.date.localeCompare(a.package.date));
+
 		for (const {package: package_} of results) {
 			const users = [
 				package_.author,

--- a/test.js
+++ b/test.js
@@ -7,5 +7,5 @@ test('invalid input', async t => {
 
 test('valid username', async t => {
 	t.is(await npmEmail('sindresorhus'), 'sindresorhus@gmail.com');
-	t.is(await npmEmail('vdemedes'), 'vdemedes@gmail.com');
+	t.is(await npmEmail('vdemedes'), 'vadimdemedes@hey.com');
 });


### PR DESCRIPTION
Currently, the lib iterates over results from the npms.io API, but the first results are often the oldest. If a user changes its e-mail address ([example](https://api.npms.io/v2/search?q=maintainer:bokub)), your library still returns the old one.

This PR sorts results by date, the most recent being the first one.